### PR TITLE
Parsing configuration file

### DIFF
--- a/libnest/Cargo.toml
+++ b/libnest/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Benjamin Grange <benjamin.grange@epitech.eu>"]
 
 [dependencies]
+toml = "0.4"

--- a/libnest/src/config.rs
+++ b/libnest/src/config.rs
@@ -1,7 +1,13 @@
 //! Nest configuration parsing and handle.
 
+extern crate toml;
+
 use std::path::PathBuf;
 use std::slice::Iter;
+use std::fs::File;
+use std::io::BufReader;
+use std::io::prelude::Read;
+use std;
 
 use repository::Repository;
 
@@ -23,8 +29,12 @@ use repository::Repository;
 #[derive(Debug)]
 pub struct Config {
     cache: PathBuf,
+    installation_dir: PathBuf,
     repositories: Vec<Repository>,
 }
+
+static DEFAULT_CACHE_DIR: &'static str = "/var/lib/nest/cache/";
+static DEFAULT_INSTALLATION_DIR: &'static str = "/tmp/";
 
 impl Config {
     /// Creates a default configuration.
@@ -43,28 +53,62 @@ impl Config {
     /// let config = Config::new();
     /// ```
     pub fn new() -> Config {
-        Config {
-            cache: PathBuf::from("/var/lib/nest/cache/"),
-            repositories: Vec::new(),
+        let config_file_path = "Config.toml";
+
+        if let Ok(conf) = Config::parse_conf(config_file_path) {
+            println!("Using {} as config file", config_file_path);
+
+            if let Some(conf_map) = conf.as_table() {
+                let cache_path =
+                    Config::get_or_default_str(conf_map, "cache_dir", DEFAULT_CACHE_DIR);
+                let install_path =
+                    Config::get_or_default_str(conf_map, "install_dir", DEFAULT_INSTALLATION_DIR);
+                Config {
+                    cache: PathBuf::from(cache_path),
+                    installation_dir: PathBuf::from(install_path),
+                    repositories: Vec::new(),
+                }
+            } else {
+                return Config::default();
+            }
+        } else {
+            Config::default()
         }
     }
 
-    /// Returns the path holding the the cache of each repository.
+    /// Returns the path holding the cache of each repository.
     ///
     /// # Examples
     ///
     /// ```
-    /// extern crate libnest;
+    /// # extern crate libnest;
     ///
     /// use std::path::Path;
-    /// use libnest::config::Config;
+    /// # use libnest::config::Config;
     ///
-    /// let config = Config::new();
+    /// let config = Config::default();
     ///
     /// assert_eq!(config.cache(), Path::new("/var/lib/nest/cache"));
     /// ```
     pub fn cache(&self) -> &PathBuf {
         &self.cache
+    }
+
+    /// Returns the path of the installation directory.
+    ///
+    /// # Examples
+    /// ```
+    /// # extern crate libnest;
+    ///
+    /// use std::path::Path;
+    /// # use libnest::config::Config;
+    ///
+    /// let config = Config::default();
+    ///
+    /// assert_eq!(config.installation_dir(), Path::new("/tmp"));
+    /// ```
+    pub fn installation_dir(&self) -> &PathBuf {
+        &self.installation_dir
     }
 
     /// Adds the given repository at the end of the list of repositories, meaning it has the lowest
@@ -109,8 +153,83 @@ impl Config {
     }
 }
 
+#[derive(Debug)]
+enum ParseConfError {
+    Io(std::io::Error),
+    Deserialize(toml::de::Error),
+}
+
+impl Config {
+    fn get_or_default_str<'a>(
+        conf_map: &'a toml::value::Table,
+        key: &'static str,
+        default: &'a str,
+    ) -> &'a str {
+        if let Some(value) = conf_map.get(key) {
+            if let Some(value_real_type) = value.as_str() {
+                value_real_type
+            } else {
+                eprintln!(
+                    "Config: wrong type for '{}', defaulting to '{}'",
+                    key, default
+                );
+                default
+            }
+        } else {
+            default
+        }
+    }
+
+    fn get_or_default_primitive<T, U>(
+        conf_map: &toml::value::Table,
+        key: &str,
+        default: U,
+        func: T,
+    ) -> U
+    where
+        T: Fn(&toml::value::Value) -> Option<U>,
+        U: std::fmt::Display,
+    {
+        if let Some(value) = conf_map.get(key) {
+            if let Some(value_real_type) = func(value) {
+                value_real_type
+            } else {
+                eprintln!(
+                    "Config: wrong type for '{}', defaulting to '{}'",
+                    key, default
+                );
+                default
+            }
+        } else {
+            default
+        }
+    }
+
+    fn parse_conf(conf_path: &str) -> Result<toml::Value, ParseConfError> {
+        match File::open(conf_path) {
+            Ok(file) => {
+                let mut file_reader = BufReader::new(file);
+                let mut content = String::new();
+                if let Err(e) = file_reader.read_to_string(&mut content) {
+                    return Err(ParseConfError::Io(e));
+                }
+                match content.parse::<toml::Value>() {
+                    Ok(v) => Ok(v),
+                    Err(e) => Err(ParseConfError::Deserialize(e)),
+                }
+            }
+            Err(e) => Err(ParseConfError::Io(e)),
+        }
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
-        Config::new()
+        println!("Using default configuration");
+        Config {
+            cache: PathBuf::from(DEFAULT_CACHE_DIR),
+            installation_dir: PathBuf::from(DEFAULT_INSTALLATION_DIR),
+            repositories: Vec::new(),
+        }
     }
 }

--- a/libnest/src/config.rs
+++ b/libnest/src/config.rs
@@ -49,12 +49,14 @@ pub struct Config {
 
 static DEFAULT_CACHE_DIR: &'static str = "/var/lib/nest/cache/";
 static DEFAULT_INSTALLATION_DIR: &'static str = "/tmp/";
+static DEFAULT_PROXY_PORT: i64 = 4554;
 
 impl Config {
     /// Creates a default configuration.
     ///
     /// The default configuration is:
     /// * Cache path: `/var/lib/nest/cache/`
+    /// * Installation path: `/tmp/`
     ///
     /// All other fields are empty.
     ///
@@ -77,6 +79,12 @@ impl Config {
                     Config::get_or_default_str(conf_map, "cache_dir", DEFAULT_CACHE_DIR);
                 let install_path =
                     Config::get_or_default_str(conf_map, "install_dir", DEFAULT_INSTALLATION_DIR);
+                let _proxy_port = Config::get_or_default_primitive(
+                    conf_map,
+                    "proxy_port",
+                    DEFAULT_PROXY_PORT,
+                    toml::value::Value::as_integer,
+                );
                 Config {
                     cache: PathBuf::from(cache_path),
                     installation_dir: PathBuf::from(install_path),

--- a/libnest/src/repository.rs
+++ b/libnest/src/repository.rs
@@ -118,7 +118,7 @@ impl Repository {
     /// let repo = Repository::new(&config, "test");
     /// let cache = repo.cache();
     ///
-    /// assert_eq!(cache.path(), Path::new("/var/lib/nest/cache/test"));
+    /// assert_eq!(cache.path(), config.cache().join("test"));
     /// ```
     pub fn cache(&self) -> &Cache {
         &self.cache
@@ -234,7 +234,7 @@ impl Cache {
     /// let repo = Repository::new(&config, "test");
     /// let cache = repo.cache();
     ///
-    /// assert_eq!(cache.path(), Path::new("/var/lib/nest/cache/test"));
+    /// assert_eq!(cache.path(), config.cache().join("test"));
     /// ```
     pub fn path(&self) -> &Path {
         &self.path

--- a/nest/Config.toml
+++ b/nest/Config.toml
@@ -1,0 +1,2 @@
+# cache_dir =  "/var/lib/nest/cache"
+# install_dir = "/tmp"

--- a/nest/Config.toml
+++ b/nest/Config.toml
@@ -1,2 +1,3 @@
 # cache_dir =  "/var/lib/nest/cache"
 # install_dir = "/tmp"
+# proxy_port = 5


### PR DESCRIPTION
When `Config::new()` is called, a file named `Config.toml` is read and used to set the values inside the `Config` structure.
If the file doesn't exist or is invalid, or if a required value inside doesn't exist or is of an incorrect type, a default value is used instead.